### PR TITLE
Add rollup-watch to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mocha": "^3.0.2",
     "rollup": "^0.34.7",
     "rollup-plugin-babel": "^2.6.1",
-    "rollup-plugin-istanbul": "^1.0.0"
+    "rollup-plugin-istanbul": "^1.0.0",
+    "rollup-watch": "^2.5.0"
   }
 }


### PR DESCRIPTION
So that you can use the `npm run watch` command.