### PR TITLE
point towards rollup-starter-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# See [rollup-starter-lib](https://github.com/rollup/rollup-starter-lib) for a simpler, up-to-date example of how to create a library with Rollup
+
+---
+
 # rollup-starter-project
 
 This package shows how to get started with [rollup][rollup] (and [babel][babel]) for writing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# See [rollup-starter-lib](https://github.com/rollup/rollup-starter-lib) for a simpler, up-to-date example of how to create a library with Rollup
+# See [rollup-starter-lib](https://github.com/rollup/rollup-starter-lib) and [rollup-starter-app](https://github.com/rollup/rollup-starter-app) for a simpler, up-to-date example of how to create a library or application with Rollup
 
 ---
 


### PR DESCRIPTION
Hi all

Apologies for wading in with opinions after not having paid attention to this repo for a while. I was reviewing the documentation on rollupjs.org earlier as parts of it badly need an overhaul, and it links here quite prominently.

I really think it is way, *way* too complicated for someone trying to get up and running with Rollup. There's so much advanced stuff in here — linting, transpiling, CI, test frameworks — that's extraneous to what I think this repo should be about, which is helping people understand how to fit Rollup into their workflow. Istanbul should be nowhere near a repository like this. (Not saying these things aren't useful and worth learning about — just that this isn't the place.)

Conversely, the thing that seems to confuse newcomers most often is how to handle external dependencies, particularly CommonJS ones, which this repo *doesn't* cover.

So I think we should have two much simpler starter projects — one for libraries, one for apps — and link to those instead. I've created a library one, [rollup-starter-lib](https://github.com/rollup/rollup-starter-lib), and will put rollup-starter-app together soon. 

Will leave this PR open a couple of days in case anyone has objections! Thanks.